### PR TITLE
feat: add recursive option

### DIFF
--- a/src/phone_footage_sorter/entry.py
+++ b/src/phone_footage_sorter/entry.py
@@ -17,17 +17,33 @@ def main():
         type=str,
         help="A custom name to be attached to the start of the new file names.",
     )
+    parser.add_argument(
+        "-r",
+        "--recursive",
+        action="store_true",
+        default=False,
+        help="Affect the current directory and all subdirectories.",
+    )
     args = parser.parse_args()
 
     print(f"Discovering files in {os.getcwd()}", end="")
+    if args.recursive:
+        print(" and subdirectories", end="")
 
     days: dict = {}
-    for file in os.listdir():
+    if args.recursive:
+        files = [os.path.join(dp, f) for dp, _, fn in os.walk(os.getcwd()) for f in fn]
+    else:
+        files = os.listdir()
+
+    for file in files:
         print(".", end="")
+        _, filename = os.path.split(file)
+
         try:
             if (
                 date := datetime.strptime(
-                    os.path.splitext(file)[0], "%Y%m%d_%H%M%S"
+                    os.path.splitext(filename)[0], "%Y%m%d_%H%M%S"
                 ).date()
             ) not in days:
                 days[date] = [file]
@@ -43,20 +59,26 @@ def main():
     print("\nRenaming files:")
     for day in days:
         if len(files := days[day]) == 1:
-            os.rename(
-                files[0],
+            dir, _ = os.path.split(files[0])
+            new_name = (
                 f"{args.title} - "
                 f"{day.year}-{day.month:02d}-{day.day:02d}"
-                f"{os.path.splitext(file)[1]}",
+                f"{os.path.splitext(files[0])[1]}"
             )
+            os.rename(
+                files[0],
+                os.path.join(dir, new_name),
+            )
+            print(f"  {file} --> {new_name}")
         else:
             for i, file in enumerate(sorted(files)):
+                dir, _ = os.path.split(file)
                 new_name = (
                     f"{args.title} - "
                     f"{day.year}-{day.month:02d}-{day.day:02d} - Part{i+1}"
                     f"{os.path.splitext(file)[1]}"
                 )
-                os.rename(file, new_name)
+                os.rename(file, os.path.join(dir, new_name))
                 print(f"  {file} --> {new_name}")
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -112,3 +112,30 @@ class TestFlatDir:
         assert "Renaming files:" in out
         for i, file in enumerate(files):
             assert f"{file} --> {outfiles[i]}" in out
+
+
+@pytest.mark.parametrize("custom_name", ["Training Videos", "FOO"])
+class TestSubDirs:
+    @staticmethod
+    @pytest.mark.parametrize("recursion_arg", ["-r", "--recursive"])
+    def test_renames_single_file_correctly(
+        tmp_path: Path, cwd, mocker: MockerFixture, custom_name: str, recursion_arg: str
+    ):
+        # GIVEN
+        filename = "20220202_222222.mp4"
+        subdir = "subdir"
+        (tmp_path / subdir).mkdir()
+        (tmp_path / subdir / filename).write_text("<sentinel>")
+        mocker.patch("sys.argv", ["stub_name", custom_name, recursion_arg])
+
+        # WHEN
+        with cwd(tmp_path):
+            main()
+
+        # THEN
+        expected_outpath = tmp_path / subdir / f"{custom_name} - 2022-02-02.mp4"
+        assert (
+            expected_outpath.is_file()
+        ), f"{expected_outpath}\n{os.listdir(tmp_path / subdir)}"
+        with open(expected_outpath, "r") as f:
+            assert f.read() == "<sentinel>"


### PR DESCRIPTION
Users can now specify `-r` when calling the tool in order to have files in subdirectories be included in the renaming.